### PR TITLE
Add orcid email enforcement

### DIFF
--- a/src/lib/EmailUpdateModal.svelte
+++ b/src/lib/EmailUpdateModal.svelte
@@ -1,0 +1,429 @@
+<script lang="ts">
+    import { createEventDispatcher } from "svelte";
+    import { updateUserEmail, checkAuthentication } from "./api";
+
+    export let show = false;
+    export let currentEmail = "";
+
+    const dispatch = createEventDispatcher();
+
+    let newEmail = "";
+    let isSubmitting = false;
+    let errorMessage = "";
+    let successMessage = "";
+
+    /**
+     * Validates email format
+     */
+    function isValidEmail(email: string): boolean {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return emailRegex.test(email);
+    }
+
+    /**
+     * Handles form submission
+     */
+    async function handleSubmit() {
+        errorMessage = "";
+        successMessage = "";
+
+        if (!newEmail.trim()) {
+            errorMessage = "Please enter an email address.";
+            return;
+        }
+
+        if (!isValidEmail(newEmail)) {
+            errorMessage = "Please enter a valid email address.";
+            return;
+        }
+
+        if (newEmail.toLowerCase() === currentEmail.toLowerCase()) {
+            errorMessage = "Please enter a different email address.";
+            return;
+        }
+
+        isSubmitting = true;
+
+        try {
+            await updateUserEmail(newEmail);
+            successMessage = "Email updated successfully!";
+
+            // Refresh user data
+            await checkAuthentication();
+
+            // Close modal after a brief delay to show success message
+            setTimeout(() => {
+                handleClose();
+                dispatch("emailupdated");
+            }, 1500);
+        } catch (error) {
+            errorMessage =
+                error instanceof Error
+                    ? error.message
+                    : "Failed to update email. Please try again.";
+        } finally {
+            isSubmitting = false;
+        }
+    }
+
+    /**
+     * Handles modal close
+     */
+    function handleClose() {
+        if (isSubmitting) return;
+        show = false;
+        newEmail = "";
+        errorMessage = "";
+        successMessage = "";
+        dispatch("close");
+    }
+
+    /**
+     * Handles backdrop click
+     */
+    function handleBackdropClick(event: MouseEvent) {
+        if (event.target === event.currentTarget) {
+            handleClose();
+        }
+    }
+
+    /**
+     * Handles escape key
+     */
+    function handleKeydown(event: KeyboardEvent) {
+        if (event.key === "Escape" && show && !isSubmitting) {
+            handleClose();
+        }
+    }
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+{#if show}
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div class="modal-backdrop" on:click={handleBackdropClick}>
+        <div class="modal-container md-card md-card-elevated">
+            <div class="modal-header">
+                <h3>Update Email Address</h3>
+                <button
+                    class="close-button"
+                    on:click={handleClose}
+                    disabled={isSubmitting}
+                    aria-label="Close"
+                >
+                    <span class="material-icons">close</span>
+                </button>
+            </div>
+
+            <div class="modal-body">
+                <p class="modal-description">
+                    Enter a new email address for your SIVACOR account. This
+                    will be used for notifications and communication.
+                </p>
+
+                <div class="current-email-display">
+                    <span class="label">Current Email:</span>
+                    <span class="email">{currentEmail}</span>
+                </div>
+
+                <form on:submit|preventDefault={handleSubmit}>
+                    <div class="form-group">
+                        <label for="new-email">New Email Address</label>
+                        <input
+                            id="new-email"
+                            type="email"
+                            bind:value={newEmail}
+                            placeholder="your.email@example.com"
+                            disabled={isSubmitting}
+                            autocomplete="email"
+                            required
+                        />
+                    </div>
+
+                    {#if errorMessage}
+                        <div class="message error-message">
+                            <span class="material-icons">error</span>
+                            <span>{errorMessage}</span>
+                        </div>
+                    {/if}
+
+                    {#if successMessage}
+                        <div class="message success-message">
+                            <span class="material-icons">check_circle</span>
+                            <span>{successMessage}</span>
+                        </div>
+                    {/if}
+
+                    <div class="modal-actions">
+                        <button
+                            type="button"
+                            class="md-button-text"
+                            on:click={handleClose}
+                            disabled={isSubmitting}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            class="md-button-filled"
+                            disabled={isSubmitting}
+                        >
+                            {#if isSubmitting}
+                                <div class="md-spinner small"></div>
+                                Updating...
+                            {:else}
+                                Update Email
+                            {/if}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{/if}
+
+<style>
+    .modal-backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+        padding: var(--md-spacing-md);
+        animation: fadeIn 0.2s ease-out;
+    }
+
+    @keyframes fadeIn {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 1;
+        }
+    }
+
+    .modal-container {
+        background: white;
+        border-radius: var(--md-border-radius);
+        max-width: 500px;
+        width: 100%;
+        max-height: 90vh;
+        overflow: auto;
+        animation: slideUp 0.3s ease-out;
+    }
+
+    @keyframes slideUp {
+        from {
+            transform: translateY(20px);
+            opacity: 0;
+        }
+        to {
+            transform: translateY(0);
+            opacity: 1;
+        }
+    }
+
+    .modal-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--md-spacing-lg);
+        border-bottom: 1px solid var(--md-outline-variant);
+    }
+
+    .modal-header h3 {
+        margin: 0;
+        font-size: var(--md-font-h6);
+        font-weight: 500;
+        color: var(--md-on-surface);
+    }
+
+    .close-button {
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: var(--md-spacing-xs);
+        border-radius: 50%;
+        color: var(--md-on-surface-variant);
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .close-button:hover:not(:disabled) {
+        background: var(--md-surface-variant);
+        color: var(--md-on-surface);
+    }
+
+    .close-button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .modal-body {
+        padding: var(--md-spacing-lg);
+    }
+
+    .modal-description {
+        margin: 0 0 var(--md-spacing-lg);
+        color: var(--md-on-surface-variant);
+        font-size: var(--md-font-body2);
+        line-height: 1.5;
+    }
+
+    .current-email-display {
+        display: flex;
+        flex-direction: column;
+        gap: var(--md-spacing-xs);
+        padding: var(--md-spacing-md);
+        background: var(--md-surface-variant);
+        border-radius: var(--md-radius-xs);
+        margin-bottom: var(--md-spacing-lg);
+    }
+
+    .current-email-display .label {
+        font-size: var(--md-font-caption);
+        color: var(--md-on-surface-variant);
+        font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+
+    .current-email-display .email {
+        font-size: var(--md-font-body1);
+        color: var(--md-on-surface);
+        font-family: monospace;
+    }
+
+    .form-group {
+        margin-bottom: var(--md-spacing-lg);
+    }
+
+    .form-group label {
+        display: block;
+        margin-bottom: var(--md-spacing-sm);
+        font-size: var(--md-font-body2);
+        font-weight: 500;
+        color: var(--md-on-surface);
+    }
+
+    .form-group input {
+        width: 100%;
+        padding: var(--md-spacing-sm) var(--md-spacing-md);
+        border: 2px solid var(--md-outline-variant);
+        border-radius: var(--md-radius-xs);
+        font-size: var(--md-font-body1);
+        transition: border-color 0.2s ease;
+    }
+
+    .form-group input:focus {
+        outline: none;
+        border-color: var(--md-primary);
+    }
+
+    .form-group input:disabled {
+        background: var(--md-surface-variant);
+        cursor: not-allowed;
+    }
+
+    .message {
+        display: flex;
+        align-items: center;
+        gap: var(--md-spacing-sm);
+        padding: var(--md-spacing-sm) var(--md-spacing-md);
+        border-radius: var(--md-radius-xs);
+        margin-bottom: var(--md-spacing-md);
+        font-size: var(--md-font-body2);
+    }
+
+    .error-message {
+        background: #fde7e9;
+        color: #c62828;
+        border: 1px solid #ef5350;
+    }
+
+    .error-message .material-icons {
+        color: #c62828;
+    }
+
+    .success-message {
+        background: #e8f5e9;
+        color: #2e7d32;
+        border: 1px solid #66bb6a;
+    }
+
+    .success-message .material-icons {
+        color: #2e7d32;
+    }
+
+    .modal-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--md-spacing-sm);
+        margin-top: var(--md-spacing-lg);
+    }
+
+    .md-button-text,
+    .md-button-filled {
+        padding: var(--md-spacing-sm) var(--md-spacing-lg);
+        border: none;
+        border-radius: var(--md-radius-xs);
+        font-size: var(--md-font-body2);
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        gap: var(--md-spacing-xs);
+    }
+
+    .md-button-text {
+        background: none;
+        color: var(--md-primary);
+    }
+
+    .md-button-text:hover:not(:disabled) {
+        background: var(--md-surface-variant);
+    }
+
+    .md-button-filled {
+        background: var(--md-primary);
+        color: white;
+    }
+
+    .md-button-filled:hover:not(:disabled) {
+        background: var(--md-primary-dark);
+        box-shadow: var(--md-shadow-md);
+    }
+
+    .md-button-text:disabled,
+    .md-button-filled:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .md-spinner.small {
+        width: 16px;
+        height: 16px;
+        border-width: 2px;
+    }
+
+    @media (max-width: 768px) {
+        .modal-container {
+            max-width: 100%;
+            margin: var(--md-spacing-md);
+        }
+
+        .modal-header,
+        .modal-body {
+            padding: var(--md-spacing-md);
+        }
+    }
+</style>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -197,6 +197,37 @@ export async function checkAuthentication() {
 }
 
 /**
+ * Updates the current user's email address.
+ * @param {string} newEmail - The new email address to set.
+ * @returns {Promise<User>} The updated user object.
+ */
+export async function updateUserEmail(newEmail: string): Promise<User> {
+    const currentUser = getCurrentUser();
+    if (!currentUser || !currentUser._id) {
+        throw new Error('User not logged in or user ID not available.');
+    }
+
+    // API requires firstName and lastName to be sent along with email as query parameters
+    const firstName = currentUser.firstName || currentUser.login || 'User';
+    const lastName = currentUser.lastName || '';
+
+    const query = new URLSearchParams({
+        email: newEmail,
+        firstName: firstName,
+        lastName: lastName,
+    });
+
+    const endpoint = `/user/${currentUser._id}?${query.toString()}`;
+    const response = await api(endpoint, {
+        method: 'PUT',
+    });
+
+    // Update the user store with the new data
+    user.set(response);
+    return response;
+}
+
+/**
  * Logs out the user.
  */
 export async function logout() {

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -1,7 +1,0 @@
-import { writable } from 'svelte/store';
-
-// Represents the user object (or null if unauthenticated)
-export const user = writable(null);
-
-// Represents the loading state during the initial authentication check
-export const authLoading = writable(true);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,0 +1,20 @@
+import { writable, derived } from 'svelte/store';
+
+interface User {
+    _id: string;
+    login: string;
+    email: string;
+    [key: string]: any;
+}
+
+// Represents the user object (or null if unauthenticated)
+export const user = writable<User | null>(null);
+
+// Represents the loading state during the initial authentication check
+export const authLoading = writable<boolean>(true);
+
+// Derived store to check if user has invalid ORCID email
+export const hasInvalidOrcidEmail = derived(user, ($user) => {
+    if (!$user || !$user.email) return false;
+    return /^\d{4}.*@orcid\.org$/.test($user.email);
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
     import { goto } from "$app/navigation";
     import { page } from "$app/stores"; // Import the page store
     import { checkAuthentication, setAuthToken } from "../lib/api";
-    import { authLoading } from "../lib/stores";
+    import { authLoading, user } from "../lib/stores";
     import Banner from "../lib/Banner.svelte";
     import "../app.css";
     import { browser } from "$app/environment";
@@ -20,6 +20,41 @@
         showBanner = false;
         sessionStorage.setItem("bannerDismissed", "true");
     }
+
+    /**
+     * Check if the email is an invalid ORCID email (starts with 4 digits and ends with @orcid.org)
+     */
+    function isInvalidOrcidEmail(email: string): boolean {
+        if (!email) return false;
+        return /^\d{4}.*@orcid\.org$/.test(email);
+    }
+
+    /**
+     * Show warning dialog for invalid ORCID emails
+     */
+    function showOrcidEmailWarning() {
+        if (!browser) return;
+
+        const hasSeenWarning = sessionStorage.getItem("orcidEmailWarningSeen");
+        if (hasSeenWarning === "true") return;
+
+        const message =
+            `Your ORCID account does not have a valid public email address.\n\n` +
+            `We recommend updating your email address to ensure proper communication.\n\n` +
+            `You can update your email:\n` +
+            `• On ORCID.org: Make your email public in your ORCID profile settings\n` +
+            `• Locally on our system: Contact support to update your email`;
+
+        alert(message);
+        sessionStorage.setItem("orcidEmailWarningSeen", "true");
+    }
+
+    // Reactive statement to check for invalid ORCID emails when user logs in
+    /* 
+    $: if ($user && $user.email && isInvalidOrcidEmail($user.email)) {
+        showOrcidEmailWarning();
+    }
+    */
 
     onMount(async () => {
         const url = new URL($page.url);


### PR DESCRIPTION
This pull request adds support for detecting invalid ORCID email addresses and prompting users to update their email if necessary. It introduces a warning and modal UI in the job runner, a new API function to update the user's email, and refactors the user store to TypeScript with a derived store for email validity. These changes improve user experience and ensure users have a valid public email for their account.

**User Email Validation and Update Workflow:**

- Added a derived store `hasInvalidOrcidEmail` in `stores.ts` to automatically detect if the user's email matches the invalid ORCID pattern (starts with 4 digits and ends with `@orcid.org`).
- Updated `JobRunner.svelte` to:
  - Disable the "Run Replication Workflow" button and show a tooltip if the user has an invalid ORCID email.
  - Display a warning message with options to update the email locally (via a modal) or at ORCID.org, including new UI elements and styles. [[1]](diffhunk://#diff-7232085a6c2a1fd73ea1cc879e9e63b6fe12c9307a467bccc27f43a2adbcdfa8R452-R482) [[2]](diffhunk://#diff-7232085a6c2a1fd73ea1cc879e9e63b6fe12c9307a467bccc27f43a2adbcdfa8R504-R507) [[3]](diffhunk://#diff-7232085a6c2a1fd73ea1cc879e9e63b6fe12c9307a467bccc27f43a2adbcdfa8R739-R825)
  - Import the new store and modal components to support this workflow. [[1]](diffhunk://#diff-7232085a6c2a1fd73ea1cc879e9e63b6fe12c9307a467bccc27f43a2adbcdfa8R6-R7) [[2]](diffhunk://#diff-7232085a6c2a1fd73ea1cc879e9e63b6fe12c9307a467bccc27f43a2adbcdfa8R28-R30)

**API and Store Refactoring:**

- Added `updateUserEmail` function to `api.ts` to allow updating the user's email address via a PUT request, and update the user store upon success.
- Migrated `stores.js` to `stores.ts`, adding TypeScript types and moving logic for user/auth state and email validation. [[1]](diffhunk://#diff-3c43777c542413bc2dd43b75e2e97cef43d8eeef595596dae59432bc0014bba6L1-L7) [[2]](diffhunk://#diff-136913045bfb3f7fe5871d8872351e71c3d66b989eee6a148e5a94321650ae84R1-R20)
- Updated imports in `+layout.svelte` to use the new TypeScript store.

**(Additional context for maintainers: there are also commented-out and legacy warning mechanisms in `+layout.svelte` for ORCID email, but the main workflow is now in the job runner UI.)**